### PR TITLE
Hw4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ build/
 
 ### VS Code ###
 .vscode/
+
+### Env variables ###
+.env

--- a/bot/pom.xml
+++ b/bot/pom.xml
@@ -90,7 +90,7 @@
         </dependency>
         <dependency>
             <groupId>org.wiremock</groupId>
-            <artifactId>wiremock</artifactId>
+            <artifactId>wiremock-standalone</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/bot/pom.xml
+++ b/bot/pom.xml
@@ -66,7 +66,6 @@
             <artifactId>lombok</artifactId>
             <optional>true</optional>
         </dependency>
-
         <!-- Tests -->
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/bot/pom.xml
+++ b/bot/pom.xml
@@ -123,6 +123,12 @@
             <artifactId>kafka</artifactId>
             <scope>test</scope>
         </dependency>
+        <!-- Open API -->
+        <dependency>
+            <groupId>org.springdoc</groupId>
+            <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+            <version>2.3.0</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/bot/src/main/java/edu/java/bot/LinkBot.java
+++ b/bot/src/main/java/edu/java/bot/LinkBot.java
@@ -1,0 +1,54 @@
+package edu.java.bot;
+
+import com.pengrad.telegrambot.TelegramBot;
+import com.pengrad.telegrambot.UpdatesListener;
+import com.pengrad.telegrambot.model.BotCommand;
+import com.pengrad.telegrambot.model.Update;
+import com.pengrad.telegrambot.request.SetMyCommands;
+import edu.java.bot.commands.Command;
+import edu.java.bot.configuration.ApplicationConfig;
+import edu.java.bot.services.UserMessageProcessor;
+import java.net.URISyntaxException;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import java.util.List;
+import java.util.Objects;
+
+@Component
+public class LinkBot extends TelegramBot {
+    private static final Logger LOGGER = LogManager.getLogger();
+    private final UserMessageProcessor userMessageProcessor;
+
+    @Autowired
+    public LinkBot(ApplicationConfig config, UserMessageProcessor userMessageProcessor, List<Command> commands) {
+        super(config.telegramToken());
+        this.userMessageProcessor = userMessageProcessor;
+
+        List<BotCommand> botCommands = commands.stream().map(Command::toApiCommand).toList();
+        execute(new SetMyCommands(botCommands.toArray(BotCommand[]::new)));
+        setUpdatesListener(this::processUpdate, e -> {
+            if (e.response() != null) {
+                e.response().errorCode();
+                e.response().description();
+            } else {
+                LOGGER.error("Some problem with updates from telegram");
+            }
+        });
+    }
+
+    public int processUpdate(List<Update> updates) {
+        for (Update update : updates) {
+            if (!Objects.isNull(update.message())) {
+                try {
+                    execute(userMessageProcessor.process(update));
+                } catch (URISyntaxException e) {
+                    LOGGER.error("Failed to process update", e);
+                }
+            }
+        }
+        return UpdatesListener.CONFIRMED_UPDATES_ALL;
+    }
+
+}

--- a/bot/src/main/java/edu/java/bot/LinkBot.java
+++ b/bot/src/main/java/edu/java/bot/LinkBot.java
@@ -9,12 +9,14 @@ import edu.java.bot.commands.Command;
 import edu.java.bot.configuration.ApplicationConfig;
 import edu.java.bot.services.UserMessageProcessor;
 import java.net.URISyntaxException;
+import java.util.List;
+import java.util.Objects;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
-import java.util.List;
-import java.util.Objects;
+
+
 
 @Component
 public class LinkBot extends TelegramBot {

--- a/bot/src/main/java/edu/java/bot/commands/Command.java
+++ b/bot/src/main/java/edu/java/bot/commands/Command.java
@@ -1,0 +1,19 @@
+package edu.java.bot.commands;
+
+import com.pengrad.telegrambot.model.BotCommand;
+import com.pengrad.telegrambot.model.Update;
+import com.pengrad.telegrambot.request.SendMessage;
+import java.net.URISyntaxException;
+
+public interface Command {
+    String name();
+
+    String description();
+
+    SendMessage execute(Update update) throws URISyntaxException;
+
+    default BotCommand toApiCommand() {
+        return new BotCommand(name(), description());
+    }
+
+}

--- a/bot/src/main/java/edu/java/bot/commands/CommandDescription.java
+++ b/bot/src/main/java/edu/java/bot/commands/CommandDescription.java
@@ -1,0 +1,16 @@
+package edu.java.bot.commands;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum CommandDescription {
+    START("/start", "зарегистрировать пользователя"),
+    HELP("/help", "вывести окно с командами"),
+    TRACK("/track", "начать отслеживание ссылки"),
+    UNTRACK("/untrack", "прекратить отслеживание ссылки"),
+    LIST("/list", "показать список отслеживаемых ссылок");
+    private final String name;
+    private final String description;
+}

--- a/bot/src/main/java/edu/java/bot/commands/Help.java
+++ b/bot/src/main/java/edu/java/bot/commands/Help.java
@@ -3,7 +3,6 @@ package edu.java.bot.commands;
 import com.pengrad.telegrambot.model.Update;
 import com.pengrad.telegrambot.request.SendMessage;
 import edu.java.bot.messages.InfoMessage;
-import edu.java.bot.services.UserManager;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -11,7 +10,7 @@ import org.springframework.stereotype.Component;
 @Component
 @RequiredArgsConstructor
 public class Help implements Command {
-    private final List<Command> allComands;
+    private final List<Command> allCommands;
     private final CommandDescription info = CommandDescription.HELP;
 
     @Override
@@ -28,7 +27,7 @@ public class Help implements Command {
     public SendMessage execute(Update update) {
         StringBuilder response = new StringBuilder();
         response.append(InfoMessage.SUPPORTED_COMMANDS.getMessage());
-        for (Command botCommand: allComands) {
+        for (Command botCommand: allCommands) {
             response.append(botCommand.name());
             response.append(" : ").append(botCommand.description()).append("\n");
         }

--- a/bot/src/main/java/edu/java/bot/commands/Help.java
+++ b/bot/src/main/java/edu/java/bot/commands/Help.java
@@ -1,0 +1,38 @@
+package edu.java.bot.commands;
+
+import com.pengrad.telegrambot.model.Update;
+import com.pengrad.telegrambot.request.SendMessage;
+import edu.java.bot.messages.InfoMessage;
+import edu.java.bot.services.UserManager;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class Help implements Command {
+    private final List<Command> allComands;
+    private final CommandDescription info = CommandDescription.HELP;
+
+    @Override
+    public String name() {
+        return info.getName();
+    }
+
+    @Override
+    public String description() {
+        return info.getDescription();
+    }
+
+    @Override
+    public SendMessage execute(Update update) {
+        StringBuilder response = new StringBuilder();
+        response.append(InfoMessage.SUPPORTED_COMMANDS.getMessage());
+        for (Command botCommand: allComands) {
+            response.append(botCommand.name());
+            response.append(" : ").append(botCommand.description()).append("\n");
+        }
+        return new SendMessage(update.message().chat().id(), response.toString());
+    }
+
+}

--- a/bot/src/main/java/edu/java/bot/commands/ListCommand.java
+++ b/bot/src/main/java/edu/java/bot/commands/ListCommand.java
@@ -1,13 +1,14 @@
 package edu.java.bot.commands;
 
-import java.util.Set;
-import lombok.RequiredArgsConstructor;
 import com.pengrad.telegrambot.model.Update;
 import com.pengrad.telegrambot.request.SendMessage;
 import edu.java.bot.messages.ErrorMessage;
 import edu.java.bot.messages.InfoMessage;
 import edu.java.bot.services.UserManager;
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
+
 
 
 @Component

--- a/bot/src/main/java/edu/java/bot/commands/ListCommand.java
+++ b/bot/src/main/java/edu/java/bot/commands/ListCommand.java
@@ -1,0 +1,55 @@
+package edu.java.bot.commands;
+
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
+import com.pengrad.telegrambot.model.Update;
+import com.pengrad.telegrambot.request.SendMessage;
+import edu.java.bot.messages.ErrorMessage;
+import edu.java.bot.messages.InfoMessage;
+import edu.java.bot.services.UserManager;
+import org.springframework.stereotype.Component;
+
+
+@Component
+@RequiredArgsConstructor
+public class ListCommand implements Command {
+    private final UserManager userManager;
+    private final CommandDescription info = CommandDescription.LIST;
+
+    @Override
+    public String name() {
+        return info.getName();
+    }
+
+    @Override
+    public String description() {
+        return info.getDescription(); }
+
+    @Override
+    public SendMessage execute(Update update) {
+        StringBuilder response = new StringBuilder();
+
+        Long userId = update.message().from().id();
+        Set<String> githubLinks = userManager.getGithubLinks().get(userId);
+        Set<String> stackOverflowLinks = userManager.getStackOverflowLinks().get(userId);
+
+        if (githubLinks.isEmpty() && stackOverflowLinks.isEmpty()) {
+            response.append(ErrorMessage.EMPTY_LIST.getMessage());
+        } else {
+            response.append(InfoMessage.LINK_LIST.getMessage());
+            if (!githubLinks.isEmpty()) {
+                response.append(InfoMessage.GITHUB_LINK.getMessage());
+            }
+            for (String link : githubLinks) {
+                response.append(link).append("\n");
+            }
+            if (!stackOverflowLinks.isEmpty()) {
+                response.append(InfoMessage.STACKOVERFLOW_LINK.getMessage());
+            }
+            for (String link : stackOverflowLinks) {
+                response.append(link).append("\n");
+            }
+        }
+        return new SendMessage(update.message().chat().id(), response.toString());
+    }
+}

--- a/bot/src/main/java/edu/java/bot/commands/Start.java
+++ b/bot/src/main/java/edu/java/bot/commands/Start.java
@@ -1,0 +1,39 @@
+package edu.java.bot.commands;
+
+import com.pengrad.telegrambot.model.Update;
+import com.pengrad.telegrambot.model.User;
+import com.pengrad.telegrambot.request.SendMessage;
+import edu.java.bot.messages.ErrorMessage;
+import edu.java.bot.messages.SuccessMessage;
+import edu.java.bot.services.UserManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class Start implements Command {
+    private final UserManager userManager;
+    private final CommandDescription info = CommandDescription.START;
+
+    @Override
+    public String name() {
+        return info.getName();
+    }
+
+    @Override
+    public String description() {
+        return info.getDescription(); }
+
+    @Override
+    public SendMessage execute(Update update) {
+        User producer = update.message().from();
+        String response = "";
+        if (!userManager.containsUser(producer)) {
+            userManager.add(update.message().from());
+            response = SuccessMessage.SIGNUP_SUCCESS.getMessage();
+        } else {
+            response = ErrorMessage.ALREADY_EXIST.getMessage();
+        }
+        return new SendMessage(update.message().chat().id(), response);
+    }
+}

--- a/bot/src/main/java/edu/java/bot/commands/Track.java
+++ b/bot/src/main/java/edu/java/bot/commands/Track.java
@@ -3,9 +3,10 @@ package edu.java.bot.commands;
 import com.pengrad.telegrambot.model.Update;
 import com.pengrad.telegrambot.request.SendMessage;
 import edu.java.bot.services.UserManager;
+import java.net.URISyntaxException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
-import java.net.URISyntaxException;
+
 
 @Component
 @RequiredArgsConstructor

--- a/bot/src/main/java/edu/java/bot/commands/Track.java
+++ b/bot/src/main/java/edu/java/bot/commands/Track.java
@@ -1,0 +1,33 @@
+package edu.java.bot.commands;
+
+import com.pengrad.telegrambot.model.Update;
+import com.pengrad.telegrambot.request.SendMessage;
+import edu.java.bot.services.UserManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import java.net.URISyntaxException;
+
+@Component
+@RequiredArgsConstructor
+public class Track implements Command {
+    private final UserManager userManager;
+    private final CommandDescription info = CommandDescription.TRACK;
+
+    @Override
+    public String name() {
+        return info.getName();
+    }
+
+    @Override
+    public String description() {
+        return info.getDescription();
+    }
+
+    @Override
+    public SendMessage execute(Update update) throws URISyntaxException {
+        Long chatId = update.message().chat().id();
+        String[] messages = update.message().text().split(" +", 2);
+        String response = userManager.addLink(update.message().from(), messages[messages.length - 1]);
+        return new SendMessage(chatId, response);
+    }
+}

--- a/bot/src/main/java/edu/java/bot/commands/Untrack.java
+++ b/bot/src/main/java/edu/java/bot/commands/Untrack.java
@@ -1,0 +1,32 @@
+package edu.java.bot.commands;
+
+import com.pengrad.telegrambot.model.Update;
+import com.pengrad.telegrambot.request.SendMessage;
+import edu.java.bot.services.UserManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import java.net.URISyntaxException;
+
+@Component
+@RequiredArgsConstructor
+public class Untrack implements Command {
+    private final UserManager userManager;
+    private final CommandDescription info = CommandDescription.UNTRACK;
+
+    @Override
+    public String name() {
+        return info.getName();
+    }
+
+    @Override
+    public String description() {
+        return info.getDescription(); }
+
+    @Override
+    public SendMessage execute(Update update) throws URISyntaxException {
+        Long chatId = update.message().chat().id();
+        String[] messages = update.message().text().split(" +", 2);
+        String response = userManager.removeLink(update.message().from(), messages[messages.length - 1]);
+        return new SendMessage(chatId, response);
+    }
+}

--- a/bot/src/main/java/edu/java/bot/commands/Untrack.java
+++ b/bot/src/main/java/edu/java/bot/commands/Untrack.java
@@ -3,9 +3,10 @@ package edu.java.bot.commands;
 import com.pengrad.telegrambot.model.Update;
 import com.pengrad.telegrambot.request.SendMessage;
 import edu.java.bot.services.UserManager;
+import java.net.URISyntaxException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
-import java.net.URISyntaxException;
+
 
 @Component
 @RequiredArgsConstructor

--- a/bot/src/main/java/edu/java/bot/configuration/ApplicationConfig.java
+++ b/bot/src/main/java/edu/java/bot/configuration/ApplicationConfig.java
@@ -1,12 +1,13 @@
 package edu.java.bot.configuration;
 
 import jakarta.validation.constraints.NotEmpty;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.validation.annotation.Validated;
 
 @Validated
 @ConfigurationProperties(prefix = "app", ignoreUnknownFields = false)
-public record ApplicationConfig(
+public record ApplicationConfig(@Value("${APP_TELEGRAM_TOKEN}")
     @NotEmpty
     String telegramToken
 ) {

--- a/bot/src/main/java/edu/java/bot/messages/ErrorMessage.java
+++ b/bot/src/main/java/edu/java/bot/messages/ErrorMessage.java
@@ -1,0 +1,18 @@
+package edu.java.bot.messages;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum ErrorMessage {
+    ALREADY_EXIST("Пользователь уже зарегистрирован"),
+    EMPTY_LIST("Список отслеживаемых ссылок пуст. Воспользуйтесь командой /track для добавления ссылки"),
+    INVALID_URL("Неверный формат ссылки. Попробуйте еще раз"),
+    UNKNOWN_ERROR("Неизвестная ошибка"),
+    UNSUPPORTED_LINK("Бот не поддерживает отслеживание данного ресурса"),
+    UNKNOWN_LINK("Вы не отслеживаете данную ссылку"),
+    UNKNOWN_COMMAND("Неизвестная команда. Вопользуйтесь командой /help для просмотра доступных команд"),
+    NO_SUCH_USER("Для использования бота требуется регистрация. Нажмите /start, чтобы зарегистрироваться");
+    private final String message;
+}

--- a/bot/src/main/java/edu/java/bot/messages/InfoMessage.java
+++ b/bot/src/main/java/edu/java/bot/messages/InfoMessage.java
@@ -1,0 +1,15 @@
+package edu.java.bot.messages;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum InfoMessage {
+    SUPPORTED_COMMANDS("Список команд:\n"),
+    SUPPORTED_SOURCE("Сайты доступные для отслеживания:\n"),
+    LINK_LIST("Список отслеживаемых ссылок:\n"),
+    GITHUB_LINK("GitHub:\n"),
+    STACKOVERFLOW_LINK("StackOverflow:\n");
+    private final String message;
+}

--- a/bot/src/main/java/edu/java/bot/messages/SuccessMessage.java
+++ b/bot/src/main/java/edu/java/bot/messages/SuccessMessage.java
@@ -6,7 +6,7 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public enum SuccessMessage {
-    SIGNUP_SUCCESS("Вы успешно зарегистрированы в системе. Воспользуйтесь командой \\help для вызова справки"),
+    SIGNUP_SUCCESS("Вы успешно зарегистрированы в системе. Воспользуйтесь командой /help для вызова справки"),
     LINK_ADDED("Ссылка успешно добавлена"),
     LINK_REMOVED("Ссылка удалена");
     private final String message;

--- a/bot/src/main/java/edu/java/bot/messages/SuccessMessage.java
+++ b/bot/src/main/java/edu/java/bot/messages/SuccessMessage.java
@@ -1,0 +1,13 @@
+package edu.java.bot.messages;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum SuccessMessage {
+    SIGNUP_SUCCESS("Вы успешно зарегистрированы в системе. Воспользуйтесь командой \\help для вызова справки"),
+    LINK_ADDED("Ссылка успешно добавлена"),
+    LINK_REMOVED("Ссылка удалена");
+    private final String message;
+}

--- a/bot/src/main/java/edu/java/bot/services/LinkManager.java
+++ b/bot/src/main/java/edu/java/bot/services/LinkManager.java
@@ -1,0 +1,45 @@
+package edu.java.bot.services;
+
+import org.springframework.stereotype.Component;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.regex.Pattern;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+
+@Component
+@SuppressWarnings("checkstyle:MemberName")
+public class LinkManager implements LinkValidator {
+    private Logger LOGGER = LogManager.getLogger();
+    private final String github = "github.com";
+    private final String stackOverflow = "stackoverflow.com";
+    private final String linkPattern =
+        "^(https?)(://)\\w+.\\w{2,}/*[a-zA-Z0-9~@#%&+-=_/|]*";
+
+    @Override
+    public boolean isValid(String s) {
+        return Pattern.matches(linkPattern, s);
+    }
+
+    @Override
+    public URI makeURI(String link) throws URISyntaxException {
+        try {
+            return new URI(link);
+        } catch (URISyntaxException e) {
+            LOGGER.error("ERROR: given link is invalid");
+            return null;
+        }
+    }
+
+    @Override
+    public boolean isGitLink(URI link) {
+        return github.equals(link.getHost());
+    }
+
+    @Override
+    public boolean isStackLink(URI link) {
+        return stackOverflow.equals(link.getHost());
+    }
+
+}

--- a/bot/src/main/java/edu/java/bot/services/LinkManager.java
+++ b/bot/src/main/java/edu/java/bot/services/LinkManager.java
@@ -1,12 +1,11 @@
 package edu.java.bot.services;
 
-import org.springframework.stereotype.Component;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.regex.Pattern;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-
+import org.springframework.stereotype.Component;
 
 @Component
 @SuppressWarnings("checkstyle:MemberName")

--- a/bot/src/main/java/edu/java/bot/services/LinkValidator.java
+++ b/bot/src/main/java/edu/java/bot/services/LinkValidator.java
@@ -1,0 +1,16 @@
+package edu.java.bot.services;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+
+public interface LinkValidator {
+
+    boolean isValid(String s);
+
+    URI makeURI(String s) throws URISyntaxException;
+
+    boolean isGitLink(URI link);
+
+    boolean isStackLink(URI link);
+
+}

--- a/bot/src/main/java/edu/java/bot/services/UserManager.java
+++ b/bot/src/main/java/edu/java/bot/services/UserManager.java
@@ -3,14 +3,14 @@ package edu.java.bot.services;
 import com.pengrad.telegrambot.model.User;
 import edu.java.bot.messages.ErrorMessage;
 import edu.java.bot.messages.SuccessMessage;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Repository;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
 
 @Getter
 @RequiredArgsConstructor

--- a/bot/src/main/java/edu/java/bot/services/UserManager.java
+++ b/bot/src/main/java/edu/java/bot/services/UserManager.java
@@ -1,0 +1,64 @@
+package edu.java.bot.services;
+
+import com.pengrad.telegrambot.model.User;
+import edu.java.bot.messages.ErrorMessage;
+import edu.java.bot.messages.SuccessMessage;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+
+@Getter
+@RequiredArgsConstructor
+@Repository
+public class UserManager {
+    private final LinkManager linkManager;
+    private Map<Long, User> allUsers = new HashMap<>();
+    private Map<Long, HashSet<String>> stackOverflowLinks = new HashMap<>();
+    private Map<Long, HashSet<String>> githubLinks = new HashMap<>();
+
+    public void add(User user) {
+        allUsers.put(user.id(), user);
+        stackOverflowLinks.put(user.id(), new HashSet<>());
+        githubLinks.put(user.id(), new HashSet<>());
+    }
+
+    public boolean containsUser(User user) {
+        return allUsers.containsKey(user.id());
+    }
+
+
+    public String addLink(User user, String link) throws URISyntaxException {
+        if (!linkManager.isValid(link)) {
+            return ErrorMessage.INVALID_URL.getMessage();
+        }
+        URI uri = linkManager.makeURI(link);
+        if (linkManager.isGitLink(uri)) {
+            githubLinks.get(user.id()).add(link);
+        } else if (linkManager.isStackLink(uri)) {
+            stackOverflowLinks.get(user.id()).add(link);
+        } else {
+            return ErrorMessage.UNSUPPORTED_LINK.getMessage();
+        }
+        return SuccessMessage.LINK_ADDED.getMessage();
+    }
+
+    public String removeLink(User user, String link) throws URISyntaxException {
+        if (!linkManager.isValid(link)) {
+            return ErrorMessage.INVALID_URL.getMessage();
+        }
+        URI uri = linkManager.makeURI(link);
+        if (linkManager.isGitLink(uri) && githubLinks.get(user.id()).contains(link)) {
+            githubLinks.get(user.id()).remove(link);
+        } else if (linkManager.isStackLink(uri) && stackOverflowLinks.get(user.id()).contains(link)) {
+            stackOverflowLinks.get(user.id()).remove(link);
+        } else {
+            return ErrorMessage.UNKNOWN_LINK.getMessage();
+        }
+        return SuccessMessage.LINK_REMOVED.getMessage();
+    }
+}

--- a/bot/src/main/java/edu/java/bot/services/UserMessageProcessor.java
+++ b/bot/src/main/java/edu/java/bot/services/UserMessageProcessor.java
@@ -6,15 +6,15 @@ import com.pengrad.telegrambot.request.SendMessage;
 import edu.java.bot.commands.Command;
 import edu.java.bot.commands.CommandDescription;
 import edu.java.bot.messages.ErrorMessage;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Service;
 import java.net.URISyntaxException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
 
 @Service
 public class UserMessageProcessor {

--- a/bot/src/main/java/edu/java/bot/services/UserMessageProcessor.java
+++ b/bot/src/main/java/edu/java/bot/services/UserMessageProcessor.java
@@ -1,0 +1,60 @@
+package edu.java.bot.services;
+
+import com.pengrad.telegrambot.model.Update;
+import com.pengrad.telegrambot.model.User;
+import com.pengrad.telegrambot.request.SendMessage;
+import edu.java.bot.commands.Command;
+import edu.java.bot.commands.CommandDescription;
+import edu.java.bot.messages.ErrorMessage;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import java.net.URISyntaxException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+@Service
+public class UserMessageProcessor {
+    private static final Logger LOGGER = LogManager.getLogger();
+    private final UserManager userManager;
+    private final Map<String, Command> botCommands;
+
+    @Autowired
+    public UserMessageProcessor(List<Command> botCommands, UserManager userManager) {
+        this.userManager = userManager;
+        this.botCommands = new HashMap<>();
+
+        for (Command command: botCommands) {
+            this.botCommands.put(command.name(), command);
+        }
+    }
+
+    public SendMessage process(Update update) throws URISyntaxException {
+        if (Objects.isNull(update.message())) {
+            return null;
+        }
+        Long chatId = update.message().chat().id();
+        User producer = update.message().from();
+        String userMessage = update.message().text();
+        String commandName = userMessage.split(" +")[0];
+
+        LOGGER.info("User with chatId = %d has sent %s".formatted(chatId, userMessage));
+        if (userManager.containsUser(producer) || commandName.equals(CommandDescription.START.getName())) {
+            Command command = botCommands.get(commandName);
+            if (!Objects.isNull(command)) {
+                LOGGER.info("Executing command: %s".formatted(command.name()));
+                return command.execute(update);
+            } else {
+                LOGGER.info("No such command: %s".formatted(commandName));
+                new SendMessage(chatId, ErrorMessage.UNKNOWN_COMMAND.getMessage());
+            }
+        } else {
+            LOGGER.info("Cannot find user with chatId = %d".formatted(chatId));
+            new SendMessage(chatId, ErrorMessage.NO_SUCH_USER.getMessage());
+        }
+        return new SendMessage(chatId, ErrorMessage.UNKNOWN_ERROR.getMessage());
+    }
+}

--- a/bot/src/main/resources/application.yml
+++ b/bot/src/main/resources/application.yml
@@ -1,5 +1,5 @@
 app:
-  telegram-token: unset
+  telegram-token: ${APP_TELEGRAM_TOKEN}
 
 spring:
   application:

--- a/bot/src/test/java/edu/java/bot/commands/CommandTest.java
+++ b/bot/src/test/java/edu/java/bot/commands/CommandTest.java
@@ -9,12 +9,16 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import java.util.List;
 import static org.mockito.Mockito.lenient;
 
 @ExtendWith(MockitoExtension.class)
 public abstract class CommandTest {
     @Mock
     protected UserManager userManager;
+
+    @Mock
+    protected List<Command> allCommands;
 
     @Mock
     protected Update update;
@@ -29,10 +33,12 @@ public abstract class CommandTest {
     protected Chat chat;
 
 
+
     @BeforeEach
     public void setUp() {
         lenient().when(update.message()).thenReturn(message);
         lenient().when(update.message().from()).thenReturn(user);
+        lenient().when(user.id()).thenReturn(666L);
         lenient().when(message.chat()).thenReturn(chat);
     }
 

--- a/bot/src/test/java/edu/java/bot/commands/CommandTest.java
+++ b/bot/src/test/java/edu/java/bot/commands/CommandTest.java
@@ -1,0 +1,41 @@
+package edu.java.bot.commands;
+
+import com.pengrad.telegrambot.model.Chat;
+import com.pengrad.telegrambot.model.Message;
+import com.pengrad.telegrambot.model.Update;
+import com.pengrad.telegrambot.model.User;
+import edu.java.bot.services.UserManager;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import static org.mockito.Mockito.lenient;
+
+@ExtendWith(MockitoExtension.class)
+public abstract class CommandTest {
+    @Mock
+    protected UserManager userManager;
+
+    @Mock
+    protected Update update;
+
+    @Mock
+    protected Message message;
+
+    @Mock
+    protected User user;
+
+    @Mock
+    protected Chat chat;
+
+
+    @BeforeEach
+    public void setUp() {
+        lenient().when(update.message()).thenReturn(message);
+        lenient().when(update.message().from()).thenReturn(user);
+        lenient().when(message.chat()).thenReturn(chat);
+    }
+
+    abstract void commandNameTest();
+    abstract void commandDescriptionTest();
+}

--- a/bot/src/test/java/edu/java/bot/commands/HelpTest.java
+++ b/bot/src/test/java/edu/java/bot/commands/HelpTest.java
@@ -4,10 +4,17 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import java.util.List;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @ExtendWith(MockitoExtension.class)
+@SpringBootTest
 public class HelpTest extends CommandTest {
+    @Autowired
+    List<Command> allCommands;
+
     @InjectMocks
     private Help helpCommand;
 
@@ -23,4 +30,19 @@ public class HelpTest extends CommandTest {
         assertEquals(helpCommand.description(), CommandDescription.HELP.getDescription());
     }
 
+    @Test
+    void containsSameCommandsTest() {
+        List<String> expectedNames = List.of("/help", "/list", "/start", "/track", "/untrack");
+        List<String> commandNames = allCommands.stream().map(Command::name).toList();
+        assertEquals(commandNames, expectedNames);
+
+    }
+
+    @Test
+    void containsSameDescriptionTest() {
+        List<String> expectedDescription = List.of("вывести окно с командами", "показать список отслеживаемых ссылок",
+            "зарегистрировать пользователя", "начать отслеживание ссылки", "прекратить отслеживание ссылки");
+        List<String> commandDescription = allCommands.stream().map(Command::description).toList();
+        assertEquals(commandDescription, expectedDescription);
+    }
 }

--- a/bot/src/test/java/edu/java/bot/commands/HelpTest.java
+++ b/bot/src/test/java/edu/java/bot/commands/HelpTest.java
@@ -1,0 +1,26 @@
+package edu.java.bot.commands;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.junit.jupiter.MockitoExtension;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@ExtendWith(MockitoExtension.class)
+public class HelpTest extends CommandTest {
+    @InjectMocks
+    private Help helpCommand;
+
+    @Test
+    @Override
+    void commandNameTest() {
+        assertEquals(helpCommand.name(), CommandDescription.HELP.getName());
+    }
+
+    @Test
+    @Override
+    void commandDescriptionTest() {
+        assertEquals(helpCommand.description(), CommandDescription.HELP.getDescription());
+    }
+
+}

--- a/bot/src/test/java/edu/java/bot/commands/ListCommandTest.java
+++ b/bot/src/test/java/edu/java/bot/commands/ListCommandTest.java
@@ -1,10 +1,17 @@
 package edu.java.bot.commands;
 
+import com.pengrad.telegrambot.request.SendMessage;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Map;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 public class ListCommandTest extends CommandTest {
@@ -14,14 +21,58 @@ public class ListCommandTest extends CommandTest {
     @Test
     @Override
     void commandNameTest() {
-        assertEquals(listCommand.name(), CommandDescription.START.getName());
+        assertEquals(listCommand.name(), CommandDescription.LIST.getName());
     }
 
     @Test
     @Override
     void commandDescriptionTest() {
-        assertEquals(listCommand.description(), CommandDescription.START.getDescription());
+        assertEquals(listCommand.description(), CommandDescription.LIST.getDescription());
     }
 
+    @Test
+    void emptyListTest() {
+        Long userId = user.id();
+        when(userManager.getGithubLinks()).thenReturn(Map.of(userId, new HashSet<>()));
+        when(userManager.getStackOverflowLinks()).thenReturn(Map.of(userId, new HashSet<>()));
+        SendMessage result = listCommand.execute(update);
+        assertEquals("Список отслеживаемых ссылок пуст. Воспользуйтесь командой /track для добавления ссылки",
+            result.getParameters().get("text"));
+    }
 
+    @Test
+    void gitHubListTest() {
+        Long userId = user.id();
+        when(userManager.getGithubLinks()).thenReturn(Map.of(userId, new HashSet<>(
+            Arrays.asList("https://github.com/rust-lang/rust",
+                "https://github.com/nodejs/node"))));
+        when(userManager.getStackOverflowLinks()).thenReturn(Map.of(userId, new HashSet<>()));
+        String expectedResponse = """
+            Список отслеживаемых ссылок:
+            GitHub:
+            https://github.com/nodejs/node
+            https://github.com/rust-lang/rust
+            """;
+        SendMessage result = listCommand.execute(update);
+        assertEquals(expectedResponse,
+            result.getParameters().get("text"));
+    }
+
+    @Test
+    void stackOverflowLinkTest() {
+        Long userId = user.id();
+        when(userManager.getStackOverflowLinks()).thenReturn(Map.of(userId, new HashSet<>(
+            Arrays.asList("https://stackoverflow.com/questions/78023671/where-is-the-order-in-which-elf-relocations-are-applied-specified",
+                "https://stackoverflow.com/questions/78049674/regex-to-split-a-column-in-r-after-the-second-pipe-and-after-the-second-t"))));
+        when(userManager.getGithubLinks()).thenReturn(Map.of(userId, new HashSet<>()));
+        String expectedResponse = """
+            Список отслеживаемых ссылок:
+            StackOverflow:
+            https://stackoverflow.com/questions/78049674/regex-to-split-a-column-in-r-after-the-second-pipe-and-after-the-second-t
+            https://stackoverflow.com/questions/78023671/where-is-the-order-in-which-elf-relocations-are-applied-specified
+            """;
+        SendMessage result = listCommand.execute(update);
+        assertEquals(expectedResponse,
+            result.getParameters().get("text"));
+    }
 }

--- a/bot/src/test/java/edu/java/bot/commands/ListCommandTest.java
+++ b/bot/src/test/java/edu/java/bot/commands/ListCommandTest.java
@@ -1,0 +1,27 @@
+package edu.java.bot.commands;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.junit.jupiter.MockitoExtension;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@ExtendWith(MockitoExtension.class)
+public class ListCommandTest extends CommandTest {
+    @InjectMocks
+    private ListCommand listCommand;
+
+    @Test
+    @Override
+    void commandNameTest() {
+        assertEquals(listCommand.name(), CommandDescription.START.getName());
+    }
+
+    @Test
+    @Override
+    void commandDescriptionTest() {
+        assertEquals(listCommand.description(), CommandDescription.START.getDescription());
+    }
+
+
+}

--- a/bot/src/test/java/edu/java/bot/commands/StartTest.java
+++ b/bot/src/test/java/edu/java/bot/commands/StartTest.java
@@ -1,0 +1,28 @@
+package edu.java.bot.commands;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.junit.jupiter.MockitoExtension;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@ExtendWith(MockitoExtension.class)
+public class StartTest extends CommandTest {
+    @InjectMocks
+    private Start startCommand;
+
+    @Test
+    @Override
+    void commandNameTest() {
+        assertEquals(startCommand.name(), CommandDescription.START.getName());
+    }
+
+    @Test
+    @Override
+    void commandDescriptionTest() {
+        assertEquals(startCommand.description(), CommandDescription.START.getDescription());
+    }
+
+}

--- a/bot/src/test/java/edu/java/bot/commands/StartTest.java
+++ b/bot/src/test/java/edu/java/bot/commands/StartTest.java
@@ -1,15 +1,18 @@
 package edu.java.bot.commands;
 
+import com.pengrad.telegrambot.request.SendMessage;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.junit.jupiter.MockitoExtension;
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 public class StartTest extends CommandTest {
+
     @InjectMocks
     private Start startCommand;
 
@@ -23,6 +26,23 @@ public class StartTest extends CommandTest {
     @Override
     void commandDescriptionTest() {
         assertEquals(startCommand.description(), CommandDescription.START.getDescription());
+    }
+
+    @Test
+    void addNewUserTest() {
+        when(userManager.containsUser(user)).thenReturn(false);
+        SendMessage result = startCommand.execute(update);
+        assertEquals("Вы успешно зарегистрированы в системе. Воспользуйтесь командой /help для вызова справки",
+            result.getParameters().get("text"));
+        verify(userManager).add(user);
+    }
+
+    @Test
+    void addExistingUserTest() {
+        when(userManager.containsUser(user)).thenReturn(true);
+        SendMessage result = startCommand.execute(update);
+        assertEquals("Пользователь уже зарегистрирован", result.getParameters().get("text"));
+        verify(userManager, never()).add(user);
     }
 
 }

--- a/bot/src/test/java/edu/java/bot/commands/TrackTest.java
+++ b/bot/src/test/java/edu/java/bot/commands/TrackTest.java
@@ -1,0 +1,27 @@
+package edu.java.bot.commands;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.junit.jupiter.MockitoExtension;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@ExtendWith(MockitoExtension.class)
+public class TrackTest extends CommandTest {
+    @InjectMocks
+    private Track track;
+
+    @Test
+    @Override
+    void commandNameTest() {
+        assertEquals(track.name(), CommandDescription.TRACK.getName());
+    }
+
+    @Test
+    @Override
+    void commandDescriptionTest() {
+        assertEquals(track.description(), CommandDescription.TRACK.getDescription());
+    }
+
+
+}

--- a/bot/src/test/java/edu/java/bot/commands/TrackTest.java
+++ b/bot/src/test/java/edu/java/bot/commands/TrackTest.java
@@ -9,19 +9,18 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 @ExtendWith(MockitoExtension.class)
 public class TrackTest extends CommandTest {
     @InjectMocks
-    private Track track;
+    private Track trackCommand;
 
     @Test
     @Override
     void commandNameTest() {
-        assertEquals(track.name(), CommandDescription.TRACK.getName());
+        assertEquals(trackCommand.name(), CommandDescription.TRACK.getName());
     }
 
     @Test
     @Override
     void commandDescriptionTest() {
-        assertEquals(track.description(), CommandDescription.TRACK.getDescription());
+        assertEquals(trackCommand.description(), CommandDescription.TRACK.getDescription());
     }
-
 
 }

--- a/bot/src/test/java/edu/java/bot/commands/UntrackTest.java
+++ b/bot/src/test/java/edu/java/bot/commands/UntrackTest.java
@@ -9,19 +9,18 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 @ExtendWith(MockitoExtension.class)
 public class UntrackTest extends CommandTest {
     @InjectMocks
-    private Track track;
+    private Untrack untrack;
 
     @Test
     @Override
     void commandNameTest() {
-        assertEquals(track.name(), CommandDescription.TRACK.getName());
+        assertEquals(untrack.name(), CommandDescription.UNTRACK.getName());
     }
 
     @Test
     @Override
     void commandDescriptionTest() {
-        assertEquals(track.description(), CommandDescription.TRACK.getDescription());
+        assertEquals(untrack.description(), CommandDescription.UNTRACK.getDescription());
     }
-
 
 }

--- a/bot/src/test/java/edu/java/bot/commands/UntrackTest.java
+++ b/bot/src/test/java/edu/java/bot/commands/UntrackTest.java
@@ -1,0 +1,27 @@
+package edu.java.bot.commands;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.junit.jupiter.MockitoExtension;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@ExtendWith(MockitoExtension.class)
+public class UntrackTest extends CommandTest {
+    @InjectMocks
+    private Track track;
+
+    @Test
+    @Override
+    void commandNameTest() {
+        assertEquals(track.name(), CommandDescription.TRACK.getName());
+    }
+
+    @Test
+    @Override
+    void commandDescriptionTest() {
+        assertEquals(track.description(), CommandDescription.TRACK.getDescription());
+    }
+
+
+}

--- a/bot/src/test/java/edu/java/bot/services/LinkManagerTest.java
+++ b/bot/src/test/java/edu/java/bot/services/LinkManagerTest.java
@@ -1,0 +1,56 @@
+package edu.java.bot.services;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import java.net.URI;
+import java.net.URISyntaxException;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+public class LinkManagerTest {
+    private LinkManager linkManager;
+    @BeforeEach
+    void init() {
+        linkManager = new LinkManager();
+    }
+
+    @ParameterizedTest
+    @CsvSource({"https://github.com, true", "affdkmosi.., false"})
+    void testIsValid(String link, boolean expected) {
+        assertEquals(expected, linkManager.isValid(link));
+    }
+
+    @ParameterizedTest
+    @CsvSource({"https://github.com, true", "https://stackoverflow.com, true"})
+    void testMakeURI(String link, boolean expected) throws URISyntaxException {
+        try {
+            assertEquals(expected, linkManager.makeURI(link) != null);
+        } catch (URISyntaxException e) {
+            assertFalse(expected);
+        }
+    }
+
+    @ParameterizedTest
+    @CsvSource({"https://github.com/tamarinvs19/theory_university, true", "https://stackoverflow.com, false",
+        "https://habr.com/ru/articles/591587/, false"})
+    void testIsGitLink(String link, boolean expectedResult) {
+        try {
+            assertEquals(expectedResult, linkManager.isGitLink(new URI(link)));
+        } catch (URISyntaxException e) {
+            Assertions.fail("invalid URI caused exception");
+        }
+    }
+
+    @ParameterizedTest
+    @CsvSource({"https://stackoverflow.com, true", "https://github.com, false",
+        "https://habr.com/ru/articles/591587/, false"})
+    void testIsStackLink(String link, boolean expectedResult) {
+        try {
+            assertEquals(expectedResult, linkManager.isStackLink(new URI(link)));
+        } catch (URISyntaxException e) {
+            Assertions.fail("invalid URI caused exception");
+        }
+    }
+}

--- a/bot/src/test/java/edu/java/bot/services/UserManagerTest.java
+++ b/bot/src/test/java/edu/java/bot/services/UserManagerTest.java
@@ -1,0 +1,80 @@
+package edu.java.bot.services;
+
+import com.pengrad.telegrambot.model.User;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Map;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class UserManagerTest {
+    private UserManager userManager;
+    private LinkManager linkManager;
+    private final Long testId = 123123123L;
+    private User user;
+
+    @BeforeEach
+    void setUp() {
+        linkManager = mock(LinkManager.class);
+        userManager = new UserManager(linkManager);
+        user = new User(testId);
+    }
+
+    @Test
+    void testAddUser() {
+        userManager.add(user);
+        Map<Long, User> allUsers = userManager.getAllUsers();
+        assertTrue(allUsers.containsKey(testId));
+        assertEquals(user, allUsers.get(testId));
+    }
+
+    @Test
+    void testContainsUser() {
+        userManager.add(user);
+        assertTrue(userManager.containsUser(user));
+    }
+
+    @Test
+    void testAddValidLink() throws URISyntaxException {
+        userManager.add(user);
+        String validLink = "https://github.com/tamarinvs19/theory_university";
+        when(linkManager.isValid(validLink)).thenReturn(true);
+        URI uri = linkManager.makeURI(validLink);
+        when(linkManager.isGitLink(uri)).thenReturn(true);
+        assertEquals("Ссылка успешно добавлена", userManager.addLink(user, validLink));
+        assertTrue(userManager.getGithubLinks().get(testId).contains(validLink));
+    }
+
+    @Test
+    void testAddInvalidLink() throws URISyntaxException {
+        String invalidLink = "invalid";
+        when(linkManager.isValid(invalidLink)).thenReturn(false);
+        assertEquals("Неверный формат ссылки. Попробуйте еще раз", userManager.addLink(user, invalidLink));
+    }
+
+    @Test
+    void testRemoveExistingLink() throws URISyntaxException {
+        String link = "https://github.com/tamarinvs19/theory_university";
+        userManager.add(user);
+        userManager.getGithubLinks().get(testId).add(link);
+        when(linkManager.isGitLink(any())).thenReturn(true);
+        when(linkManager.isValid(any())).thenReturn(true);
+        assertEquals("Ссылка удалена", userManager.removeLink(user, link));
+        assertFalse(userManager.getGithubLinks().get(testId).contains(link));
+    }
+
+    @Test
+    void testRemoveNonExistingLink() throws URISyntaxException {
+        String link = "https://github.com/tamarinvs19/theory_university";
+        userManager.add(user);
+        when(linkManager.isGitLink(any())).thenReturn(true);
+        when(linkManager.isValid(any())).thenReturn(true);
+        assertEquals("Вы не отслеживаете данную ссылку", userManager.removeLink(user, link));
+    }
+}

--- a/compose.yml
+++ b/compose.yml
@@ -11,9 +11,26 @@ services:
       - postgresql:/var/lib/postgresql/data
     networks:
       - backend
+  liquibase-migrations:
+    image: liquibase/liquibase:4.25
+    depends_on:
+      - postgresql
+    command:
+      - --changelog-file=master.xml
+      - --driver=org.postgresql.Driver
+      - --url=jdbc:postgresql://postgresql:5432/scrapper
+      - --username=postgres
+      - --password=postgres
+      - update
+    volumes:
+      - ./migrations:/liquibase/changelog
+    networks:
+      - backend
 
 volumes:
   postgresql: { }
 
 networks:
   backend: { }
+
+

--- a/migrations/create_chat.sql
+++ b/migrations/create_chat.sql
@@ -1,0 +1,7 @@
+--liquibase formatted sql
+--changeset ado591:01-create_chat.sql
+CREATE TABLE IF NOT EXISTS chat
+(
+    id BIGINT PRIMARY KEY,
+    user_id BIGINT NOT NULL
+);

--- a/migrations/create_chatLink.sql
+++ b/migrations/create_chatLink.sql
@@ -1,0 +1,8 @@
+--liquibase formatted sql
+--changeset ado591:03-create-chatLink.sql
+CREATE TABLE IF NOT EXISTS chat_link
+(
+    chat_id BIGINT NOT NULL REFERENCES chat (id) ON DELETE CASCADE,
+    link_id BIGINT NOT NULL REFERENCES link (id) ON DELETE CASCADE
+
+);

--- a/migrations/create_link.sql
+++ b/migrations/create_link.sql
@@ -1,0 +1,10 @@
+--liquibase formatted sql
+--changeset ado591:02-create_link.sql
+CREATE TABLE IF NOT EXISTS link
+(
+    id BIGINT PRIMARY KEY,
+    url VARCHAR(255) UNIQUE NOT NULL,
+    service_name VARCHAR(255) NOT NULL,
+    last_check_time TIMESTAMP WITH TIME ZONE NOT NULL
+
+);

--- a/migrations/master.xml
+++ b/migrations/master.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--suppress XmlUnusedNamespaceDeclaration -->
+<databaseChangeLog
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext"
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.8.xsd
+       http://www.liquibase.org/xml/ns/dbchangelog-ext https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd">
+
+    <include file="create_chat.sql"/>
+    <include file="create_link.sql"/>
+    <include file="create_chatLink.sql"/>
+</databaseChangeLog>

--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
             </dependency>
             <dependency>
                 <groupId>org.wiremock</groupId>
-                <artifactId>wiremock</artifactId>
+                <artifactId>wiremock-standalone</artifactId>
                 <version>${wiremock.version}</version>
             </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -23,6 +23,11 @@
         <!-- Spring -->
         <spring-boot.version>3.2.2</spring-boot.version>
         <spring-cloud.version>2023.0.0</spring-cloud.version>
+        <spring-jdbc.version>3.2.2</spring-jdbc.version>
+
+        <!-- Database -->
+        <postgres.version>42.7.2</postgres.version>
+        <liquibase.version>4.24.0</liquibase.version>
 
         <!-- Other -->
         <jetbrains-annotations.version>24.1.0</jetbrains-annotations.version>
@@ -116,6 +121,26 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-params</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-jdbc</artifactId>
+            <version>${spring-jdbc.version}</version>
+        </dependency>
+
+        <!-- Database -->
+        <dependency>
+            <groupId>org.postgresql</groupId>
+            <artifactId>postgresql</artifactId>
+            <version>${postgres.version}</version>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.liquibase</groupId>
+            <artifactId>liquibase-core</artifactId>
+            <version>${liquibase.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/scrapper/pom.xml
+++ b/scrapper/pom.xml
@@ -85,7 +85,7 @@
         </dependency>
         <dependency>
             <groupId>org.wiremock</groupId>
-            <artifactId>wiremock</artifactId>
+            <artifactId>wiremock-standalone</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/scrapper/pom.xml
+++ b/scrapper/pom.xml
@@ -118,6 +118,20 @@
             <artifactId>kafka</artifactId>
             <scope>test</scope>
         </dependency>
+        <!-- Open API -->
+        <dependency>
+            <groupId>org.springdoc</groupId>
+            <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+            <version>2.3.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-jdbc</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.postgresql</groupId>
+            <artifactId>postgresql</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/scrapper/src/main/java/edu/java/clients/GitHubClient.java
+++ b/scrapper/src/main/java/edu/java/clients/GitHubClient.java
@@ -1,0 +1,24 @@
+package edu.java.clients;
+
+import edu.java.data.GitDTO;
+import org.springframework.web.reactive.function.client.WebClient;
+
+public class GitHubClient {
+    private final WebClient webClient;
+    private String baseUrl = "https://api.github.com";
+
+
+    public GitHubClient(String otherUrl) {
+        if (!otherUrl.isEmpty()) {
+            this.baseUrl = otherUrl;
+        }
+        this.webClient = WebClient.builder().baseUrl(otherUrl).build();
+    }
+
+    public GitDTO fetch(String username, String repositoryName) {
+        return webClient.get().uri("/repos/%s/%s".formatted(username, repositoryName))
+            .retrieve()
+            .bodyToMono(GitDTO.class)
+            .block();
+    }
+}

--- a/scrapper/src/main/java/edu/java/clients/StackOverflowClient.java
+++ b/scrapper/src/main/java/edu/java/clients/StackOverflowClient.java
@@ -1,0 +1,24 @@
+package edu.java.clients;
+
+import edu.java.data.StackDTO;
+import org.springframework.web.reactive.function.client.WebClient;
+
+
+public class StackOverflowClient {
+    private final WebClient webClient;
+    private String baseUrl = "https://api.stackexchange.com/2.3";
+
+    public StackOverflowClient(String otherUrl) {
+        if (!otherUrl.isEmpty()) {
+            this.baseUrl = otherUrl;
+        }
+        this.webClient = WebClient.builder().baseUrl(otherUrl).build();
+    }
+
+    public StackDTO fetch(Long questionId) {
+        return webClient.get().uri(param -> param
+                .path("/questions/%d".formatted(questionId))
+                .queryParam("site", "stackoverflow").build())
+            .retrieve().bodyToMono(StackDTO.class).block();
+    }
+}

--- a/scrapper/src/main/java/edu/java/configuration/ClientConfiguration.java
+++ b/scrapper/src/main/java/edu/java/configuration/ClientConfiguration.java
@@ -1,0 +1,32 @@
+package edu.java.configuration;
+
+import edu.java.clients.GitHubClient;
+import edu.java.clients.StackOverflowClient;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+
+@Configuration
+public class ClientConfiguration {
+    final ApplicationConfig config;
+
+    @Value("${clients.github}")
+    private String gitBaseUrl;
+    @Value("${clients.stackoverflow}")
+    private String stackBaseUrl;
+
+    public ClientConfiguration(ApplicationConfig config) {
+        this.config = config;
+    }
+
+    @Bean
+    public GitHubClient gitHubClient() {
+        return new GitHubClient(gitBaseUrl);
+    }
+
+    @Bean
+    public StackOverflowClient stackOverflowClient() {
+        return new StackOverflowClient(stackBaseUrl);
+    }
+}

--- a/scrapper/src/main/java/edu/java/data/GitDTO.java
+++ b/scrapper/src/main/java/edu/java/data/GitDTO.java
@@ -1,0 +1,16 @@
+package edu.java.data;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.NotNull;
+import java.time.OffsetDateTime;
+
+public record GitDTO(
+    @NotNull
+    @JsonProperty("name")
+    String repositoryName,
+    @NotNull
+    GitHubUser owner,
+    @NotNull
+    @JsonProperty("updated_at")
+    OffsetDateTime updatedAt
+){}

--- a/scrapper/src/main/java/edu/java/data/GitHubUser.java
+++ b/scrapper/src/main/java/edu/java/data/GitHubUser.java
@@ -1,0 +1,11 @@
+package edu.java.data;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.NotNull;
+
+public record GitHubUser(
+    @NotNull
+    @JsonProperty("login")
+    String username
+) {
+}

--- a/scrapper/src/main/java/edu/java/data/StackDTO.java
+++ b/scrapper/src/main/java/edu/java/data/StackDTO.java
@@ -1,0 +1,19 @@
+package edu.java.data;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.NotNull;
+import java.time.OffsetDateTime;
+
+public record StackDTO(
+        @NotNull
+        StackUser user,
+        @NotNull
+        @JsonProperty("question_id")
+        Long id,
+        @NotNull
+        @JsonProperty("last_activity_date")
+        OffsetDateTime lastActivity,
+        @NotNull
+        @JsonProperty("is_answered")
+        Boolean isAnswered
+){}

--- a/scrapper/src/main/java/edu/java/data/StackUser.java
+++ b/scrapper/src/main/java/edu/java/data/StackUser.java
@@ -1,0 +1,14 @@
+package edu.java.data;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.NotNull;
+
+public record StackUser(
+    @NotNull
+    @JsonProperty("display_name")
+    String topicCreator,
+    @NotNull
+    @JsonProperty("account_id")
+    Long accountId
+)
+{}

--- a/scrapper/src/main/java/edu/java/scheduler/LinkUpdateScheduler.java
+++ b/scrapper/src/main/java/edu/java/scheduler/LinkUpdateScheduler.java
@@ -1,0 +1,18 @@
+package edu.java.scheduler;
+
+import lombok.RequiredArgsConstructor;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class LinkUpdateScheduler {
+    private static final Logger LOGGER = LogManager.getLogger();
+
+    @Scheduled(fixedDelayString = "#{@scheduler.interval().toMillis()}")
+    public void update() {
+        LOGGER.info("Searching for updates");
+    }
+}

--- a/scrapper/src/main/resources/application.yml
+++ b/scrapper/src/main/resources/application.yml
@@ -7,6 +7,12 @@ app:
 spring:
   application:
     name: scrapper
+  datasource:
+    driver-class-name: org.postgresql.Driver
+    url: jdbc:postgresql://postgresql:5432/scrapper
+    username: postgres
+    password: postgres
+
 
 server:
   port: 8080

--- a/scrapper/src/main/resources/application.yml
+++ b/scrapper/src/main/resources/application.yml
@@ -13,3 +13,7 @@ server:
 
 logging:
   config: classpath:log4j2-plain.xml
+
+clients:
+  stackoverflow: https://api.stackexchange.com/2.3
+  github: https://api.github.com

--- a/scrapper/src/test/java/edu/java/scrapper/CreateDatabasesTest.java
+++ b/scrapper/src/test/java/edu/java/scrapper/CreateDatabasesTest.java
@@ -1,0 +1,45 @@
+package edu.java.scrapper;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@Testcontainers
+public class CreateDatabasesTest extends IntegrationTest {
+
+    @ParameterizedTest
+    @CsvSource({"SELECT EXISTS (SELECT FROM pg_tables WHERE tablename = 'chat');",
+        "SELECT EXISTS (SELECT FROM pg_tables WHERE tablename = 'link');",
+        "SELECT EXISTS (SELECT FROM pg_tables WHERE tablename = 'chat_link');"})
+    public void tableExistsTest(String query) {
+        try (
+            Connection connection = DriverManager.getConnection(
+                postgreSQLContainer.getJdbcUrl(),
+                postgreSQLContainer.getUsername(),
+                postgreSQLContainer.getPassword()
+            );
+            Statement statement = connection.createStatement();
+            ResultSet changelog = connection
+                .getMetaData()
+                .getTables(null, null, "databasechangelog", null);
+            ResultSet changeloglock = connection
+                .getMetaData()
+                .getTables(null, null, "databasechangeloglock", null);
+        ) {
+            Assertions.assertTrue(changelog.next());
+            Assertions.assertTrue(changeloglock.next());
+            ResultSet result = statement.executeQuery(query);
+            assertTrue(result.next());
+        } catch (SQLException sqlException) {
+            Assertions.fail("sql exception");
+        }
+    }
+
+}

--- a/scrapper/src/test/java/edu/java/scrapper/IntegrationTest.java
+++ b/scrapper/src/test/java/edu/java/scrapper/IntegrationTest.java
@@ -1,33 +1,72 @@
 package edu.java.scrapper;
 
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.nio.file.Path;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import liquibase.Contexts;
+import liquibase.LabelExpression;
+import liquibase.Liquibase;
+import liquibase.database.Database;
+import liquibase.database.DatabaseFactory;
+import liquibase.database.jvm.JdbcConnection;
+import liquibase.exception.LiquibaseException;
+import liquibase.resource.DirectoryResourceAccessor;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.Assertions;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
 import org.testcontainers.containers.JdbcDatabaseContainer;
 import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
 
 @Testcontainers
 public abstract class IntegrationTest {
-    public static PostgreSQLContainer<?> POSTGRES;
+    private static final String DOCKER_IMAGE_NAME = "postgres:16";
+    private static final String DATABASE_NAME = "scrapper";
+    private static final String DATABASE_USERNAME = "postgres";
+    private static final String DATABASE_PASS = "postgres";
+    private static final String CHANGELOG_FILE = "master.xml";
+    protected static PostgreSQLContainer<?> postgreSQLContainer;
 
     static {
-        POSTGRES = new PostgreSQLContainer<>("postgres:15")
-            .withDatabaseName("scrapper")
-            .withUsername("postgres")
-            .withPassword("postgres");
-        POSTGRES.start();
-
-        runMigrations(POSTGRES);
+        postgreSQLContainer = new PostgreSQLContainer<>(DockerImageName.parse(DOCKER_IMAGE_NAME))
+            .withDatabaseName(DATABASE_NAME)
+            .withUsername(DATABASE_USERNAME)
+            .withPassword(DATABASE_PASS);
+        postgreSQLContainer.start();
+        runMigrations(postgreSQLContainer);
     }
 
-    private static void runMigrations(JdbcDatabaseContainer<?> c) {
-        // ...
+    private static void runMigrations(JdbcDatabaseContainer<?> jdbcDatabaseContainer) {
+        Path changelogPath = new File(".").toPath().toAbsolutePath().resolve("../migrations/");
+
+        try (
+            Connection connection = DriverManager.getConnection(
+                jdbcDatabaseContainer.getJdbcUrl(),
+                jdbcDatabaseContainer.getUsername(),
+                jdbcDatabaseContainer.getPassword()
+            )
+        ) {
+            Database database = DatabaseFactory
+                .getInstance()
+                .findCorrectDatabaseImplementation(new JdbcConnection(connection));
+
+            Liquibase liquibase =
+                new Liquibase(CHANGELOG_FILE, new DirectoryResourceAccessor(changelogPath), database);
+            liquibase.update(new Contexts(), new LabelExpression());
+        } catch (SQLException | LiquibaseException | FileNotFoundException e) {
+            Assertions.fail("ошибка при выполнении миграции базы данных");
+        }
     }
 
     @DynamicPropertySource
-    static void jdbcProperties(DynamicPropertyRegistry registry) {
-        registry.add("spring.datasource.url", POSTGRES::getJdbcUrl);
-        registry.add("spring.datasource.username", POSTGRES::getUsername);
-        registry.add("spring.datasource.password", POSTGRES::getPassword);
+    public static void jdbcProperties(@NotNull DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", postgreSQLContainer::getJdbcUrl);
+        registry.add("spring.datasource.username", postgreSQLContainer::getUsername);
+        registry.add("spring.datasource.password", postgreSQLContainer::getPassword);
     }
 }


### PR DESCRIPTION
Привет! Прости, что пропала, был завал на учебе :с 
На базе IntegrationTest добавила запуск миграций + сделала небольшой тест для проверки миграции базы данных и создания нужных таблиц. Не уверена, стоит ли их разделять на 2 разных теста.

Хотела уточнить насчет разделения ссылок по сервисам. На данный момент оно актуально при добавлении в бд(в таблице link есть поле service_name) и получении списка отслеживаемых ссылок(так как группируем их по сервису). Пока что у меня из идей только фильтровать их по сервису при вызове \list, но тогда есть сценарий, когда бот будет многократно выполнять одну и ту же операцию за короткий промежуток времени. Есть ли какой-то хороший способ организовать это разделение(возможно, кэшировать этот список)? 